### PR TITLE
sold outの記述を追加

### DIFF
--- a/app/assets/stylesheets/_show.scss
+++ b/app/assets/stylesheets/_show.scss
@@ -28,10 +28,37 @@
       flex-direction: column;
       align-items: center;
       padding: 0 auto;
+
       &__top{
         height: 346px;
         display: flex;
         flex-direction: column;
+        position: relative;
+
+        .sold_out_for_show::before{
+          content: "";
+          top: 0;
+          left: 0;
+          border-bottom: 150px solid transparent;
+          border-left: 150px solid #ea352d;
+          position: absolute;
+          z-index: 100;
+        }
+        
+        .sold_out_for_show::after{
+          content:"soldout";
+          display: block;
+          top: 30px;
+          left: 8;
+          transform: rotate(-45deg);
+          position: absolute;
+          z-index: 101;
+          font-size:25px;
+          font-weight: bold;
+          color: #f8f8f8;
+        }
+
+
       }
       &__down{
         width: 620px;
@@ -134,7 +161,13 @@
       background-color: #33CCCC;
       background-size: 200% auto;
       &___btn{
+        background-color: gray;
       }
     }
   }
 }
+
+.selled_item{
+  background-color: gray;
+}
+

--- a/app/assets/stylesheets/posts.scss
+++ b/app/assets/stylesheets/posts.scss
@@ -275,6 +275,7 @@
         
      
         &__txst1{
+          position: relative;
           *{
             color: black;
           }
@@ -485,3 +486,24 @@
   margin-bottom: 12px;
 }
 
+.sold_out::before{
+  content: "";
+  top: 0;
+  left: 0;
+  border-bottom: 100px solid transparent;
+  border-left: 100px solid #ea352d;
+  position: absolute;
+  z-index: 100;
+}
+
+.sold_out::after{
+  content:"soldout";
+  display: block;
+  top: 20px;
+  left: 10;
+  transform: rotate(-45deg);
+  position: absolute;
+  z-index: 101;
+  font-size: 20px;
+  color: #f8f8f8;
+}

--- a/app/views/items/index.html.haml
+++ b/app/views/items/index.html.haml
@@ -115,6 +115,8 @@
         - image = item.images.first 
         = link_to item_path(item.id), class: 'btn100' do
           .top__category__image__left__txst1
+            - if item.buyer_id?
+              .sold_out
             = image_submit_tag image.image_name, class: "image10" , height: "150px" , width: "220px"
             .top__category__image__left__txst1__test1
               = item.name
@@ -138,6 +140,8 @@
         - image = item.images.first 
         = link_to item_path(item.id), class: 'btn100' do
           .top__category__image__left__txst1
+            - if item.buyer_id?
+              .sold_out
             = image_submit_tag image.image_name, class: "image10" , height: "150px" , width: "220px"
             .top__category__image__left__txst1__test1
               = item.name 

--- a/app/views/items/show.html.haml
+++ b/app/views/items/show.html.haml
@@ -7,7 +7,10 @@
       = @item.name
 
     .details__top__middle
+
       .details__top__middle__top
+        - if @item.buyer_id?
+          .sold_out_for_show
         = image_tag ("#{@images.first.image_name}"), class: "image111", height: "500px", width: "400px"
       .details__top__middle__down
         - @images.each do |image|
@@ -81,6 +84,7 @@
   -#   .comment
   -#     = link_to 'コメントする'
   -# 上記、実装予定のためコメントアウトで置いております：楠山
+  
   .details__item
     - if user_signed_in? && @item.seller_id == current_user.id
       .details__item__changeboxes
@@ -89,6 +93,11 @@
       .details__item__changeboxes
         .details__item__changeboxes__btn
           = link_to '削除', "#{@item.id}", method: :delete
+
+    - elsif @item.buyer_id?
+      .details__item__changeboxes.selled_item
+        .details__item__changeboxes__btn
+          購入済み
 
     - else
       .details__item__changeboxes

--- a/app/views/items/show.html.haml
+++ b/app/views/items/show.html.haml
@@ -86,18 +86,18 @@
   -# 上記、実装予定のためコメントアウトで置いております：楠山
   
   .details__item
-    - if user_signed_in? && @item.seller_id == current_user.id
+    - if @item.buyer_id?
+      .details__item__changeboxes.selled_item
+        .details__item__changeboxes__btn
+          購入済み
+
+    - elseif user_signed_in? && @item.seller_id == current_user.id
       .details__item__changeboxes
         .details__item__changeboxes__btn
           = link_to '商品の編集', edit_item_path(@item.id)
       .details__item__changeboxes
         .details__item__changeboxes__btn
           = link_to '削除', "#{@item.id}", method: :delete
-
-    - elsif @item.buyer_id?
-      .details__item__changeboxes.selled_item
-        .details__item__changeboxes__btn
-          購入済み
 
     - else
       .details__item__changeboxes


### PR DESCRIPTION
#what
購入済みの商品を判別できるよう
HTMLとCSSを変更。

#why
購入済みの商品を簡単に見分けられるようにし、
ユーザーの利便性を向上するため。