### PR TITLE
ビューの微調整

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,2 +1,5 @@
 module ApplicationHelper
+  def converting_to_jpy(price)
+    "¥#{price.to_s(:delimited, delimiter: ',')}"
+  end
 end

--- a/app/views/items/confirm.html.haml
+++ b/app/views/items/confirm.html.haml
@@ -10,8 +10,7 @@
           .confirmation__main__item__text__info
             = @item.name
             %br
-            ¥
-            = @item.price
+            = converting_to_jpy(@item.price)
             (税込)
             %br
             = @item.cost
@@ -21,8 +20,7 @@
             .confirmation__main__buy__header__box__text
               支払い金額
             .confirmation__main__buy__header__box__price
-              ¥
-              = @item.price
+              = converting_to_jpy(@item.price)
 
         .confirmation__main__buy__way
           .confirmation__main__buy__way__box

--- a/app/views/items/edit.html.haml
+++ b/app/views/items/edit.html.haml
@@ -114,7 +114,7 @@
           .main__sell__input__middle
             = f.submit '編集する', class: 'sell-item'
           .main__sell__input__bottom
-            = link_to 'もどる', '#'
+            = link_to 'もどる', item_path(params[:id])
 
 
 

--- a/app/views/items/index.html.haml
+++ b/app/views/items/index.html.haml
@@ -121,8 +121,7 @@
             .top__category__image__left__txst1__test1
               = item.name
               .top__category__image__left__txst1__test1__center1
-                = item.price
-                円
+                = converting_to_jpy(item.price)
                 .top__category__image__left__txst1__test1__center1__hosi
                   ★0
               .top__category__image__left__txst1__test1__center11
@@ -146,8 +145,7 @@
             .top__category__image__left__txst1__test1
               = item.name 
               .top__category__image__left__txst1__test1__center1
-                = item.price 
-                円
+                = converting_to_jpy(item.price)
                 .top__category__image__left__txst1__test1__center1__hosi
                   ★0
               .top__category__image__left__txst1__test1__center11

--- a/app/views/items/show.html.haml
+++ b/app/views/items/show.html.haml
@@ -16,8 +16,7 @@
         - @images.each do |image|
           = image_tag image.image_name.url, class: "image111", height: "90px", width: "140px"
     .details__top__span
-      ¥
-      = @item.price
+      = converting_to_jpy(@item.price)
 
     .details__top__itembox
       .details__top__itembox__left
@@ -45,7 +44,10 @@
         %tr
           %th ブランド
           %td
-            = @item.brand
+            - if @item.brand?
+              = @item.brand
+            - else
+              ー
         %tr
           %th 商品の状態
           %td


### PR DESCRIPTION
#what
 金額を表示する際、表記を統一
  ・区切り（,）を設定
  ・単位を￥に統一

CSSの微調整

#why
　サイト全体で統一感を出すため